### PR TITLE
Fixing SSE transport

### DIFF
--- a/src/Microsoft.AspNetCore.Sockets/ServerSentEvents.cs
+++ b/src/Microsoft.AspNetCore.Sockets/ServerSentEvents.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Sockets
         {
             context.Response.ContentType = "text/event-stream";
             context.Response.Headers["Cache-Control"] = "no-cache";
+            context.Response.Headers["Content-Encoding"] = "identity";
 
             while (true)
             {


### PR DESCRIPTION
Content-Encoding: identity disables all the transformations and therefore fixes the issue where IIS is buffering SSE data
